### PR TITLE
Specify Airflow startup commands in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
 
   airflow-webserver:
     image: apache/airflow:2.5.0
+    command: webserver
     environment:
       - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres/airflow
       - AIRFLOW__CORE__EXECUTOR=LocalExecutor
@@ -12,6 +13,7 @@ services:
 
   airflow-scheduler:
     image: apache/airflow:2.5.0
+    command: scheduler
     environment:
       - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres/airflow
       - AIRFLOW__CORE__EXECUTOR=LocalExecutor


### PR DESCRIPTION
## Summary
- configure the Airflow webserver service to launch the web UI explicitly with the webserver command
- configure the Airflow scheduler service to run the scheduler process

## Testing
- docker-compose up --build *(fails: docker-compose command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe31e468883228520f9ea2eabc4f2